### PR TITLE
fix(publish): put namespace description headings directly below 'Usage' in TOC

### DIFF
--- a/static/classy.css
+++ b/static/classy.css
@@ -325,8 +325,11 @@ nav ul {
 }
 
 nav ul ul {
-    padding-left: 15px;
     margin-bottom: 12px;
+}
+
+nav ul ul:not(.no-indent) {
+    padding-left: 15px;
     border-left: 2px solid #ddd;
 }
 


### PR DESCRIPTION
These were previously appearing after the "Usage" section in the table of contents, which didn't make sense as child doclet links (e.g. for examples, params, etc.) were above description headings in the TOC but below description headings in the page.