### PR TITLE
Add handling for TypeScript 'typeof' in types

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -100,6 +100,12 @@ exports.handlers = {
         // Class properties with default values shouldn't need to explicitly declare themselves
         if (type === Syntax.ClassProperty && !!value) e.code.value = nodeToValue(value);
     },
+    jsdocCommentFound: (e) => {
+        // Remove all "typeof" instances in comments, since JSDoc doesn't know what to do with them yet
+        while (e.comment.match(/\{(.*?)typeof\s+(.*?)}/g)) {
+            e.comment = String(e.comment ?? "").replaceAll(/\{(.*?)typeof\s+(.*?)}/g, "{$1$2}")
+        }
+    },
     parseComplete(e) {
         // Go through source files to get classdesc from class or interface constructors
         for (let sourcefile of e.sourcefiles) {


### PR DESCRIPTION
Modern IDEs use the 'typeof' keyword to denote references to a class instead of a class instance.
Unfortunately, JSDoc doesn't know how to handle this, and its equivalent is messy and confusing.
In order to accomodate this, classy will now just strip the 'typeof' keyword, and assume the description linked to the type explains whether it is expected to be a class or class instance.
This allows the 'typeof' feature to be used in IDEs without breaking documentation generation.